### PR TITLE
Implement draggable transaction editor

### DIFF
--- a/generator.html
+++ b/generator.html
@@ -12,6 +12,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
     
     <!-- AOS Animation Library -->
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
@@ -2555,18 +2556,44 @@
         .transaction-editor {
             margin-top: 24px;
         }
-        
-        
+
+        .transaction-lists {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 16px;
+            margin-bottom: 24px;
+        }
+
+        .statement-section {
+            flex: 1 1 280px;
+        }
+
+        .category-column {
+            margin-bottom: 12px;
+        }
+
+        .transaction-list {
+            min-height: 40px;
+            padding: 8px;
+            border: 1px dashed rgba(59, 130, 246, 0.3);
+            border-radius: 6px;
+        }
+
+
         /* Individual Transaction Cards */
         .transaction-card {
             background: linear-gradient(145deg, rgba(30, 41, 59, 0.8), rgba(15, 23, 42, 0.9));
             border: 1px solid rgba(59, 130, 246, 0.2);
-            border-radius: 8px;
-            padding: 12px;
-            margin-bottom: 8px;
+            border-radius: 6px;
+            padding: 4px 8px;
+            margin-bottom: 4px;
             cursor: grab;
             transition: all 0.3s ease;
             user-select: none;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            min-height: 32px;
         }
         
         .transaction-card:hover {
@@ -3266,6 +3293,51 @@
                             <div class="summary-item highlight">
                                 <span>Net Income:</span>
                                 <span id="liveNetIncome" class="amount">$0</span>
+                            </div>
+                        </div>
+
+                        <!-- Transaction Lists -->
+                        <div class="transaction-lists">
+                            <div class="statement-section">
+                                <h5>Income Statement</h5>
+                                <div class="category-column">
+                                    <h6>Revenue</h6>
+                                    <div id="income-revenue-list" class="transaction-list" data-statement="income" data-category="Revenue"></div>
+                                </div>
+                                <div class="category-column">
+                                    <h6>Expense</h6>
+                                    <div id="income-expense-list" class="transaction-list" data-statement="income" data-category="Expense"></div>
+                                </div>
+                            </div>
+                            <div class="statement-section">
+                                <h5>Cash Flow</h5>
+                                <div class="category-column">
+                                    <h6>Operating</h6>
+                                    <div id="cashflow-operating-list" class="transaction-list" data-statement="cashflow" data-category="Operating"></div>
+                                </div>
+                                <div class="category-column">
+                                    <h6>Investing</h6>
+                                    <div id="cashflow-investing-list" class="transaction-list" data-statement="cashflow" data-category="Investing"></div>
+                                </div>
+                                <div class="category-column">
+                                    <h6>Financing</h6>
+                                    <div id="cashflow-financing-list" class="transaction-list" data-statement="cashflow" data-category="Financing"></div>
+                                </div>
+                            </div>
+                            <div class="statement-section">
+                                <h5>Balance Sheet</h5>
+                                <div class="category-column">
+                                    <h6>Asset</h6>
+                                    <div id="balance-asset-list" class="transaction-list" data-statement="balance" data-category="Asset"></div>
+                                </div>
+                                <div class="category-column">
+                                    <h6>Liability</h6>
+                                    <div id="balance-liability-list" class="transaction-list" data-statement="balance" data-category="Liability"></div>
+                                </div>
+                                <div class="category-column">
+                                    <h6>Equity</h6>
+                                    <div id="balance-equity-list" class="transaction-list" data-statement="balance" data-category="Equity"></div>
+                                </div>
                             </div>
                         </div>
                         
@@ -6123,14 +6195,59 @@
 
         // Global variables for transaction editing
         let currentTransactions = [];
+        let dragInitialized = false;
+
+        function renderTransactions() {
+            document.querySelectorAll('.transaction-list').forEach(list => list.innerHTML = '');
+
+            currentTransactions.forEach(tx => {
+                const container = document.getElementById(`${tx.statement}-${tx.category.toLowerCase()}-list`);
+                if (!container) return;
+
+                const card = document.createElement('div');
+                card.className = 'transaction-card';
+                card.draggable = true;
+                card.dataset.id = tx.id;
+                card.innerHTML = `
+                    <span class="transaction-description">${tx.description}</span>
+                    <span class="transaction-amount ${tx.amount >= 0 ? 'positive' : 'negative'}">${formatCurrency(tx.amount)}</span>
+                `;
+                container.appendChild(card);
+            });
+        }
+
+        function initDragAndDrop() {
+            document.querySelectorAll('.transaction-list').forEach(list => {
+                Sortable.create(list, {
+                    group: 'transactions',
+                    animation: 150,
+                    onAdd: (evt) => {
+                        const txId = evt.item.dataset.id;
+                        const statement = evt.to.dataset.statement;
+                        const category = evt.to.dataset.category;
+                        const tx = currentTransactions.find(t => String(t.id) === String(txId));
+                        if (tx) {
+                            tx.statement = statement;
+                            tx.category = category;
+                        }
+                        updateLiveSummary();
+                    }
+                });
+            });
+        }
         
         // Initialize transaction editor when transactions tab is shown
         function showTransactionsEditor() {
             if (!window.editableTransactions) return;
-            
+
             // Clone the original transactions for editing
             currentTransactions = JSON.parse(JSON.stringify(window.editableTransactions));
-            
+
+            renderTransactions();
+            if (!dragInitialized) {
+                initDragAndDrop();
+                dragInitialized = true;
+            }
             updateLiveSummary();
         }
         
@@ -6160,6 +6277,7 @@
             if (confirm('Are you sure you want to reset all transaction changes?')) {
                 // Reset to original data
                 currentTransactions = JSON.parse(JSON.stringify(window.editableTransactions));
+                renderTransactions();
                 updateLiveSummary();
             }
         }


### PR DESCRIPTION
## Summary
- add Sortable.js
- style transaction lists and cards for editing
- create containers for each statement/category
- render cards and enable drag-and-drop

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685e6bdb2cc4832896e7245f25091a54