### PR TITLE
Show GL account info on transaction cards

### DIFF
--- a/generator.html
+++ b/generator.html
@@ -2639,7 +2639,13 @@
             font-size: 0.9rem;
             margin-bottom: 4px;
         }
-        
+
+        .transaction-account {
+            color: #94A3B8;
+            font-size: 0.8rem;
+            margin: 0 8px;
+        }
+
         .transaction-context {
             color: #94A3B8;
             font-size: 0.8rem;
@@ -6241,6 +6247,7 @@
                 card.dataset.baseId = tx.baseId;
                 card.innerHTML = `
                     <span class="transaction-description">${tx.description}</span>
+                    <span class="transaction-account">${tx.glAccount || tx.subcategory || ''}</span>
                     <span class="transaction-amount ${tx.amount >= 0 ? 'positive' : 'negative'}">${formatCurrency(tx.amount)}</span>
                 `;
                 container.appendChild(card);


### PR DESCRIPTION
## Summary
- show GL account or subcategory when rendering transaction cards
- style new account display

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e790cfef08328b0e877a47999a3da