### PR TITLE
Enhance sortable with scrolling

### DIFF
--- a/generator.html
+++ b/generator.html
@@ -6280,6 +6280,9 @@
                 Sortable.create(list, {
                     group: 'transactions',
                     animation: 150,
+                    scroll: true,
+                    scrollSensitivity: 60,
+                    scrollSpeed: 15,
                     onAdd: (evt) => {
                         const txId = evt.item.dataset.id;
                         const baseId = evt.item.dataset.baseId;


### PR DESCRIPTION
## Summary
- extend Sortable configuration in `initDragAndDrop()` to enable auto-scrolling while dragging

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e7dd1cdf483289fa0fd89e6a9312d