### PR TITLE
Add collapsible GL account sections

### DIFF
--- a/generator.html
+++ b/generator.html
@@ -2620,10 +2620,15 @@
             margin-bottom: 8px;
         }
 
+        .gl-account-section.collapsed .transaction-list {
+            display: none;
+        }
+
         .gl-account-title {
             font-size: 0.85rem;
             margin-bottom: 4px;
             font-weight: 600;
+            cursor: pointer;
         }
 
         .transaction-list {
@@ -6398,6 +6403,7 @@
             });
 
             initDragAndDrop();
+            applyCollapsedState();
             updateStatementTotals();
         }
 
@@ -6455,6 +6461,7 @@ function createGLEmptySection(statement, category, account, container) {
 
         container.appendChild(section);
         initDragAndDrop();
+        applyCollapsedState();
     }
 }
 
@@ -6495,6 +6502,33 @@ function initAddAccountButtons() {
         btn.addEventListener('click', () => {
             showAddAccountInput(btn.dataset.statement, btn.dataset.category, btn);
         });
+    });
+}
+
+function initCollapseToggle() {
+    document.addEventListener('click', (e) => {
+        if (e.target.classList.contains('gl-account-title')) {
+            const section = e.target.closest('.gl-account-section');
+            if (!section) return;
+            const key = section.dataset.glAccount;
+            const collapsed = section.classList.toggle('collapsed');
+            if (collapsed) {
+                localStorage.setItem('gl-collapsed-' + key, '1');
+            } else {
+                localStorage.removeItem('gl-collapsed-' + key);
+            }
+        }
+    });
+}
+
+function applyCollapsedState() {
+    document.querySelectorAll('.gl-account-section').forEach(section => {
+        const key = section.dataset.glAccount;
+        if (localStorage.getItem('gl-collapsed-' + key)) {
+            section.classList.add('collapsed');
+        } else {
+            section.classList.remove('collapsed');
+        }
     });
 }
         
@@ -6720,7 +6754,11 @@ function initAddAccountButtons() {
             }
         });
 
-        document.addEventListener('DOMContentLoaded', initAddAccountButtons);
+        document.addEventListener('DOMContentLoaded', () => {
+            initAddAccountButtons();
+            initCollapseToggle();
+            applyCollapsedState();
+        });
         
         function filterHistoryList() {
             const searchTerm = document.getElementById('historySearch').value.toLowerCase();


### PR DESCRIPTION
## Summary
- make GL account titles clickable and toggle their transaction lists
- hide transactions using a `.collapsed` class
- remember collapsed state with `localStorage`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685e8dbbb69c83288dfb2a2294e5fb0b