### PR TITLE
Ensure statements table renders after global load

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -8415,6 +8415,11 @@
                 
                 glAccounts = glData || [];
                 console.log('Loaded GL accounts globally:', glAccounts.length);
+
+                // Initialize UI with loaded data
+                populateAccountDropdowns();
+                renderFinancialTable();
+                updateTrialBalance();
                 
             } catch (error) {
                 console.error('Error loading financial data globally:', error);


### PR DESCRIPTION
## Summary
- update `loadFinancialDataGlobally()` to render the dashboard immediately

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a959a6474832881f33d9cc823aa50