### PR TITLE
Fix financing modal visibility

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -15047,27 +15047,17 @@
         // Financing Modal Functions
         function openFinancingModal() {
             // Close all other modals
-            document.getElementById('addFinancialModal').style.display = 'none';
-            document.getElementById('newAccountModal').style.display = 'none';
-            document.getElementById('uploadFinancialModal').style.display = 'none';
-            document.getElementById('glAccountSelectionModal').style.display = 'none';
-            document.getElementById('aparCreationModal').style.display = 'none';
-            document.getElementById('addModal').style.display = 'none';
-            document.getElementById('uploadModal').style.display = 'none';
-            
-            // Open financing modal with the exact styles that worked in console
+            document.getElementById('addFinancialModal').classList.remove('show');
+            document.getElementById('newAccountModal').classList.remove('show');
+            document.getElementById('uploadFinancialModal').classList.remove('show');
+            document.getElementById('glAccountSelectionModal').classList.remove('show');
+            document.getElementById('aparCreationModal').classList.remove('show');
+            document.getElementById('addModal').classList.remove('show');
+            document.getElementById('uploadModal').classList.remove('show');
+
+            // Show financing modal using standard modal classes
             const modal = document.getElementById('financingModal');
-            modal.style.display = 'flex';
-            modal.style.justifyContent = 'center';
-            modal.style.alignItems = 'center';
-            modal.style.background = 'rgba(0, 0, 0, 0.5)';
-            modal.style.position = 'fixed';
-            modal.style.top = '0';
-            modal.style.left = '0';
-            modal.style.width = '100%';
-            modal.style.height = '100%';
-            modal.style.zIndex = '9999';
-            
+            modal.classList.add('show');
             document.body.style.overflow = 'hidden';
             
             // Set default available date to today
@@ -15077,7 +15067,7 @@
         
         function closeFinancingModal() {
             const modal = document.getElementById('financingModal');
-            modal.style.display = 'none';
+            modal.classList.remove('show');
             document.body.style.overflow = 'auto';
             document.getElementById('financingForm').reset();
         }


### PR DESCRIPTION
## Summary
- fix the financing modal so it uses the standard `show` class
- close previously opened modals using class removal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e1977e9188328b47b16acad4a1047